### PR TITLE
Fix schedule and spinning

### DIFF
--- a/rmf_demos/config/office/config.yaml
+++ b/rmf_demos/config/office/config.yaml
@@ -43,9 +43,9 @@ robots:
       base_url: "http://127.0.0.1:8001" # API endpoint for the robot
       user: "some_user"
       password: "some_password"
-      # max_delay: 15.0 # allowed seconds of delay of the current itinerary before it gets interrupted and replanned
+      max_delay: 15.0 # allowed seconds of delay of the current itinerary before it gets interrupted and replanned
     rmf_config:
-      robot_state_update_frequency: 0.5
+      robot_state_update_frequency: 1.0
       start:
         map_name: "L1"
         waypoint: "tinyRobot1_charger"
@@ -60,7 +60,7 @@ robots:
   #     password: "some_password"
   #     # max_delay: 10.0 # allowed seconds of delay of the current itinerary before it gets interrupted and replanned
   #   rmf_config:
-  #     robot_state_update_frequency: 0.5
+  #     robot_state_update_frequency: 1.0
   #     start:
   #       map_name: "L1"
   #       waypoint: "tinyRobot2_charger"

--- a/rmf_demos/config/office/config.yaml
+++ b/rmf_demos/config/office/config.yaml
@@ -30,7 +30,7 @@ rmf_fleet:
     loop: True
     delivery: True
     clean: False
-    finishing_request: "nothing" # [park, charge, nothing]
+    finishing_request: "park" # [park, charge, nothing]
 
 # DeliveryBot CONFIG =================================================================
 
@@ -44,6 +44,7 @@ robots:
       user: "some_user"
       password: "some_password"
       max_delay: 10.0 # allowed seconds of delay of the current itinerary before it gets interrupted and replanned
+      filter_waypoints: True
     rmf_config:
       robot_state_update_frequency: 1.0
       start:
@@ -59,6 +60,7 @@ robots:
       user: "some_user"
       password: "some_password"
       max_delay: 10.0 # allowed seconds of delay of the current itinerary before it gets interrupted and replanned
+      filter_waypoints: True
     rmf_config:
       robot_state_update_frequency: 1.0
       start:

--- a/rmf_demos/config/office/config.yaml
+++ b/rmf_demos/config/office/config.yaml
@@ -53,20 +53,20 @@ robots:
       charger:
         waypoint: "tinyRobot1_charger"
   # Configuration for the second robot in this fleet if there is a second robot
-  tinyRobot2:
-    robot_config:
-      base_url: "http://127.0.0.1:8001" # API endpoint for the robot
-      user: "some_user"
-      password: "some_password"
-      # max_delay: 10.0 # allowed seconds of delay of the current itinerary before it gets interrupted and replanned
-    rmf_config:
-      robot_state_update_frequency: 0.5
-      start:
-        map_name: "L1"
-        waypoint: "tinyRobot2_charger"
-        orientation: 0.0 # radians
-      charger:
-        waypoint: "tinyRobot2_charger"
+  # tinyRobot2:
+  #   robot_config:
+  #     base_url: "http://127.0.0.1:8001" # API endpoint for the robot
+  #     user: "some_user"
+  #     password: "some_password"
+  #     # max_delay: 10.0 # allowed seconds of delay of the current itinerary before it gets interrupted and replanned
+  #   rmf_config:
+  #     robot_state_update_frequency: 0.5
+  #     start:
+  #       map_name: "L1"
+  #       waypoint: "tinyRobot2_charger"
+  #       orientation: 0.0 # radians
+  #     charger:
+  #       waypoint: "tinyRobot2_charger"
 
 # TRANSFORM CONFIG =============================================================
 # For computing transforms between Robot and RMF coordinate systems

--- a/rmf_demos/config/office/config.yaml
+++ b/rmf_demos/config/office/config.yaml
@@ -43,7 +43,7 @@ robots:
       base_url: "http://127.0.0.1:8001" # API endpoint for the robot
       user: "some_user"
       password: "some_password"
-      max_delay: 15.0 # allowed seconds of delay of the current itinerary before it gets interrupted and replanned
+      max_delay: 10.0 # allowed seconds of delay of the current itinerary before it gets interrupted and replanned
     rmf_config:
       robot_state_update_frequency: 1.0
       start:
@@ -53,20 +53,20 @@ robots:
       charger:
         waypoint: "tinyRobot1_charger"
   # Configuration for the second robot in this fleet if there is a second robot
-  # tinyRobot2:
-  #   robot_config:
-  #     base_url: "http://127.0.0.1:8001" # API endpoint for the robot
-  #     user: "some_user"
-  #     password: "some_password"
-  #     # max_delay: 10.0 # allowed seconds of delay of the current itinerary before it gets interrupted and replanned
-  #   rmf_config:
-  #     robot_state_update_frequency: 1.0
-  #     start:
-  #       map_name: "L1"
-  #       waypoint: "tinyRobot2_charger"
-  #       orientation: 0.0 # radians
-  #     charger:
-  #       waypoint: "tinyRobot2_charger"
+  tinyRobot2:
+    robot_config:
+      base_url: "http://127.0.0.1:8001" # API endpoint for the robot
+      user: "some_user"
+      password: "some_password"
+      max_delay: 10.0 # allowed seconds of delay of the current itinerary before it gets interrupted and replanned
+    rmf_config:
+      robot_state_update_frequency: 1.0
+      start:
+        map_name: "L1"
+        waypoint: "tinyRobot2_charger"
+        orientation: 0.0 # radians
+      charger:
+        waypoint: "tinyRobot2_charger"
 
 # TRANSFORM CONFIG =============================================================
 # For computing transforms between Robot and RMF coordinate systems

--- a/rmf_demos/launch/office.launch.xml
+++ b/rmf_demos/launch/office.launch.xml
@@ -20,12 +20,6 @@
       <arg name="use_sim_time" value="$(var use_sim_time)"/>
       <arg name="nav_graph_file" value="$(find-pkg-share rmf_demos_maps)/maps/office/nav_graphs/0.yaml" />
     </include>
-    <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
-      <arg name="robot_prefix" value="tinyRobot"/>
-      <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="$(var use_sim_time)"/>
-      <arg name="failover_mode" value="$(var failover_mode)"/>
-    </include>
   </group>
 
 </launch>

--- a/rmf_demos_fleet_adapter/launch/fleet_adapter.launch.xml
+++ b/rmf_demos_fleet_adapter/launch/fleet_adapter.launch.xml
@@ -2,7 +2,7 @@
 
 <launch>
 
-  <arg name="use_sim_time" default="false" description="Use the /clock topic for time to sync with simulation"/>
+  <arg name="use_sim_time" default="true" description="Use the /clock topic for time to sync with simulation"/>
   <arg name="fleet_name" description="Name of the fleet that this adapter will interface with"/>
   <arg name="nav_graph_file" default="" description="The file path of this fleet's navigation graph"/>
   <arg name="config_file" default="" description="The path of this fleet's config file"/>
@@ -14,21 +14,15 @@
         args="--config_file $(var config_file) --nav_graph $(var nav_graph_file)"
         output="both">
 
-    <param name="fleet_name" value="$(var fleet_name)"/>
-    <param name="config_file" value="$(var config_file)"/>
-    <param name="nav_graph_file" value="$(var nav_graph_file)"/>
     <param name="use_sim_time" value="$(var use_sim_time)"/>
   </node>
 
   <node pkg="rmf_demos_fleet_adapter"
         exec="fleet_adapter"
         name="$(var fleet_name)_fleet_adapter"
-        args="--config_file $(var config_file) --nav_graph $(var nav_graph_file)"
+        args="--config_file $(var config_file) --nav_graph $(var nav_graph_file) --use_sim_time"
         output="both">
 
-    <param name="fleet_name" value="$(var fleet_name)"/>
-    <param name="config_file" value="$(var config_file)"/>
-    <param name="nav_graph_file" value="$(var nav_graph_file)"/>
     <param name="use_sim_time" value="$(var use_sim_time)"/>
   </node>
 

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotClientAPI.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotClientAPI.py
@@ -63,7 +63,8 @@ class RobotAPI:
             data = response.json()
             if self.debug:
                 print(f'Response: {data}')
-            # if data['success']:
+            if not data['success']:
+                return None
             x = data['data']['position']['x']
             y = data['data']['position']['y']
             angle = data['data']['position']['yaw']
@@ -144,7 +145,7 @@ class RobotAPI:
         ''' Return True if the robot has successfully completed its previous
             navigation request. Else False.'''
         response = self.data()
-        if response is not None:
+        if response is not None and response.get('data') is not None:
             return response['data']['completed_request']
         else:
             return False

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
@@ -117,10 +117,12 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         # assert len(
         #     self.position) > 2, "Unable to get current location of the robot"
         retry_count = 0
-        while (self.position is not None and retry_count < 10):
+        while (self.position is None and retry_count < 10):
             self.position = self.get_position()
             retry_count = retry_count + 1
-            time.sleep(1)
+            time.sleep(0.5)
+        if retry_count > 19:
+            assert False, "Unable to get current location of the robot"
         self.node.get_logger().info(
             f"The robot is starting at: [{self.position[0]:.2f}, "
             f"{self.position[1]:.2f}, {self.position[2]:.2f}]")

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
@@ -383,8 +383,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         if position is not None:
             x, y = self.transforms['robot_to_rmf'].transform(
                 [position[0], position[1]])
-            theta = math.radians(position[2]) - \
-                self.transforms['orientation_offset']
+            theta = position[2] - self.transforms['orientation_offset']
             # ------------------------ #
             # IMPLEMENT YOUR CODE HERE #
             # Ensure x, y are in meters and theta in radians #

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
@@ -186,7 +186,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
             self.node.get_logger().info("Requesting robot to stop...")
             if self.api.stop():
                 break
-            time.sleep(1.0)
+            time.sleep(0.5)
         if self._follow_path_thread is not None:
             self._quit_path_event.set()
             if self._follow_path_thread.is_alive():
@@ -247,10 +247,10 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                             f"Robot {self.name} failed to navigate to "
                             f"[{x:.0f}, {y:.0f}, {theta:.0f}] coordinates. "
                             f"Retrying...")
-                        time.sleep(1.0)
+                        time.sleep(0.5)
 
                 elif self.state == RobotState.WAITING:
-                    time.sleep(1.0)
+                    time.sleep(0.5)
                     time_now = self.adapter.now()
                     with self._lock:
                         if self.target_waypoint is not None:
@@ -266,7 +266,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                                         self.path_index, timedelta(seconds=0.0))
 
                 elif self.state == RobotState.MOVING:
-                    time.sleep(1.0)
+                    time.sleep(0.5)
                     # Check if we have reached the target
                     with self._lock:
                         if (self.api.navigation_completed()):
@@ -354,7 +354,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
             with self._lock:
                 self.on_waypoint = None
                 self.on_lane = None
-            time.sleep(1.0)
+            time.sleep(0.5)
             # ------------------------ #
             # IMPLEMENT YOUR CODE HERE #
             # With whatever logic you need for docking #
@@ -365,7 +365,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                     self.node.get_logger().info("Aborting docking")
                     return
                 self.node.get_logger().info("Robot is docking...")
-                time.sleep(1.0)
+                time.sleep(0.5)
 
             with self._lock:
                 self.on_waypoint = self.dock_waypoint_index

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
@@ -74,7 +74,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         self.update_handle = None  # RobotUpdateHandle
         self.battery_soc = 1.0
         self.api = None
-        self.position = []  # (x,y,theta) in RMF coordinates (meters, radians)
+        self.position = None  # (x,y,theta) in RMF coordinates (meters, radians)
         self.initialized = False
         self.state = RobotState.IDLE
         self.dock_name = ""

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
@@ -117,7 +117,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         # assert len(
         #     self.position) > 2, "Unable to get current location of the robot"
         retry_count = 0
-        while (self.position is None and retry_count < 10):
+        while (self.position is None and retry_count < 20):
             self.position = self.get_position()
             retry_count = retry_count + 1
             time.sleep(0.5)

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
@@ -237,7 +237,7 @@ class FleetManager(Node):
             if state.destination is None:
                 return
             destination = state.destination
-            if ((msg.mode.mode == 0 or msg.mode.mode ==1) and len(msg.path) == 0) and self.disp([msg.location.x, msg.location.y], [destination.x, destination.y]) < 0.5:
+            if ((msg.mode.mode == 0 or msg.mode.mode ==1) and len(msg.path) == 0):
                 self.robots[msg.name].destination = None
 
     def disp(self, A, B):

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
@@ -151,7 +151,7 @@ class FleetManager(Node):
                 data['data']['destination_arrival_duration'] = duration
             else:
               data['data']['destination_arrival_duration'] = 0.0
-              data['completed_request'] = True
+              data['data']['completed_request'] = True
             return data
 
         @app.post('/open-rmf/rmf_demos_fm/navigate/')


### PR DESCRIPTION
Hello,

This PR aims to fix
* Robot footprint & trajectories not active (The `use_sim_time` parameter was not set to `True` for the fleet adapter nodes)
* Extra spinning by the robots (This was due to an unnecessary conversions of the reported yaw to radians [here](https://github.com/xiyuoh/rmf_demos/blob/244e824c5d6bb639e2ac8a120589c734b262f53c/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py#L384). Due to this, the fleet adapter thinks the robot is at another angle to it makes it rotate extra each time.
* Structural improvements to the fleet_manager. See the new `class State`  and `self.robots` data structure

Try this out and feel free to merge it in if everything works ok